### PR TITLE
Implemented #11

### DIFF
--- a/args.zig
+++ b/args.zig
@@ -215,10 +215,10 @@ fn parseInt(comptime T: type, str: []const u8) !T {
                 'p', 'P' => 5,  //peta
                 else => 0
             };
-            if (pow != 0)
+            
+            if (pow != 0) {
                 buf.len -= 1;
 
-            if (pow != 0) {
                 if (comptime std.math.maxInt(T) < 1024)
                     return error.Overflow;
                 var base: T = if (base1024) 1024 else 1000;


### PR DESCRIPTION
You can now end any integer argument with k, ki, m, mi, g, gi, t, ti, p, pi. If the integer type can't contain it, it will generate an error.Overflow. I wrote tests for it as well.