### PR TITLE
add a demo file for parsing with verbs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,16 +8,35 @@ pub fn build(b: *std.build.Builder) void {
     test_runner.setBuildMode(mode);
     test_runner.setTarget(target);
 
-    const test_exe = b.addExecutable("demo", "demo.zig");
-    test_exe.setBuildMode(mode);
-    test_exe.setTarget(target);
+    // Standard demo
 
-    const run_1 = test_exe.run();
-    run_1.addArgs(&[_][]const u8{
+    const demo_exe = b.addExecutable("demo", "demo.zig");
+    demo_exe.setBuildMode(mode);
+    demo_exe.setTarget(target);
+
+    const run_demo = demo_exe.run();
+    run_demo.addArgs(&[_][]const u8{
         "--output", "demo", "--with-offset", "--signed_number=-10", "--unsigned_number", "20", "--mode", "slow", "help", "this", "is", "borked",
+    });
+
+    // Demo with verbs
+
+    const demo_verb_exe = b.addExecutable("demo_verb", "demo_verb.zig");
+    demo_verb_exe.setBuildMode(mode);
+    demo_verb_exe.setTarget(target);
+
+    const run_demo_verb_1 = demo_verb_exe.run();
+    run_demo_verb_1.addArgs(&[_][]const u8{
+        "compact", "--host=localhost", "-p", "4030", "--mode", "fast", "help", "this", "is", "borked",
+    });
+    const run_demo_verb_2 = demo_verb_exe.run();
+    run_demo_verb_2.addArgs(&[_][]const u8{
+        "reload", "-f",
     });
 
     const test_step = b.step("test", "Runs the test suite.");
     test_step.dependOn(&test_runner.step);
-    test_step.dependOn(&run_1.step);
+    test_step.dependOn(&run_demo.step);
+    test_step.dependOn(&run_demo_verb_1.step);
+    test_step.dependOn(&run_demo_verb_2.step);
 }

--- a/demo_verb.zig
+++ b/demo_verb.zig
@@ -1,0 +1,64 @@
+const std = @import("std");
+const argsParser = @import("args.zig");
+
+pub fn main() !u8 {
+    var argsAllocator = std.heap.page_allocator;
+
+    const options = argsParser.parseWithVerbForCurrentProcess(
+        struct {},
+        union(enum) {
+            compact: struct {
+                // This declares long options for double hyphen
+                host: ?[]const u8 = null,
+                port: u16 = 3420,
+                mode: enum { default, special, slow, fast } = .default,
+
+                // This declares short-hand options for single hyphen
+                pub const shorthands = .{
+                    .H = "host",
+                    .p = "port",
+                };
+            },
+            reload: struct {
+                // This declares long options for double hyphen
+                force: bool = false,
+
+                // This declares short-hand options for single hyphen
+                pub const shorthands = .{
+                    .f = "force",
+                };
+            },
+        },
+        argsAllocator,
+        .print,
+    ) catch return 1;
+    defer options.deinit();
+
+    std.debug.print("executable name: {s}\n", .{options.executable_name});
+
+    switch (options.verb.?) {
+        .compact => |opts| {
+            inline for (std.meta.fields(@TypeOf(opts))) |fld| {
+                std.debug.print("\t{s} = {any}\n", .{
+                    fld.name,
+                    @field(opts, fld.name),
+                });
+            }
+        },
+        .reload => |opts| {
+            inline for (std.meta.fields(@TypeOf(opts))) |fld| {
+                std.debug.print("\t{s} = {any}\n", .{
+                    fld.name,
+                    @field(opts, fld.name),
+                });
+            }
+        },
+    }
+
+    std.debug.print("parsed positionals:\n", .{});
+    for (options.positionals) |arg| {
+        std.debug.print("\t'{s}'\n", .{arg});
+    }
+
+    return 0;
+}


### PR DESCRIPTION
`parseWithVerbForCurrentProcess` isn't tested currently.

This adds `demo_verb.zig` which is like `demo.zig` but uses `parseWithVerbForCurrentProcess`.
This also serves as an example of how to use verbs.