### PR TITLE
Document verb in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Simple-to-use argument parser with struct-based config
     - Everything after the first `--` is assumed to be a positional argument
     - A single `-` is interpreted as a positional argument which can be used as the stdin/stdout file placeholder
     - Short options with no argument can be combined into a single argument: `-dfe`
-    - Long options can use either `--option=value` or `--option value` syntax
+    - Long options can use either `--option=value` or `--option value` syntax (use `--option=--` if you need `--` as a long option argument)
+    - verbs (sub-commands), with verb specific options. Non-verb specific (global) options can come before or after the
+      verb on the command line. Non-verb option arguments are processed *before* determining verb.  (see `demo_verb.zig`)
 - Integrated support for primitive types:
     - All integer types (signed & unsigned)
     - Floating point types

--- a/args.zig
+++ b/args.zig
@@ -797,9 +797,9 @@ test "shorthand parsing (no verbs)" {
 
 test "basic parsing (with verbs)" {
     var titerator = TestIterator.init(&[_][:0]const u8{
-        "booze", // verb
-        "--output",
+        "--output",  // non-verb options can come before or after verb
         "foobar",
+        "booze", // verb
         "--with-offset",
         "--numberOfBytes",
         "-250",

--- a/demo_verb.zig
+++ b/demo_verb.zig
@@ -5,7 +5,15 @@ pub fn main() !u8 {
     var argsAllocator = std.heap.page_allocator;
 
     const options = argsParser.parseWithVerbForCurrentProcess(
-        struct {},
+        struct {
+            // this declares long option that can come before or after verb
+            output: ?[]const u8 = null,
+
+            // This declares short-hand options for single hyphen
+            pub const shorthands = .{
+                .o = "output",
+            };
+        },
         union(enum) {
             compact: struct {
                 // This declares long options for double hyphen
@@ -36,6 +44,14 @@ pub fn main() !u8 {
 
     std.debug.print("executable name: {s}\n", .{options.executable_name});
 
+    // non-verb/global options
+    inline for (std.meta.fields(@TypeOf(options.options))) |fld| {
+        std.debug.print("\t{s} = {any}\n", .{
+            fld.name,
+            @field(options.options, fld.name),
+        });
+    }
+    // verb options
     switch (options.verb.?) {
         .compact => |opts| {
             inline for (std.meta.fields(@TypeOf(opts))) |fld| {


### PR DESCRIPTION
Show in demo_verb.zig that you can have non-verb options and verb specific options.
Test that a non-verb option can come before verb.
