### PR TITLE
support verbs with void and zero sized payload types

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,10 +33,20 @@ pub fn build(b: *std.build.Builder) void {
     run_demo_verb_2.addArgs(&[_][]const u8{
         "reload", "-f",
     });
+    const run_demo_verb_3 = demo_verb_exe.run();
+    run_demo_verb_3.addArgs(&[_][]const u8{
+        "forward",
+    });
+    const run_demo_verb_4 = demo_verb_exe.run();
+    run_demo_verb_4.addArgs(&[_][]const u8{
+        "zero-sized",
+    });
 
     const test_step = b.step("test", "Runs the test suite.");
     test_step.dependOn(&test_runner.step);
     test_step.dependOn(&run_demo.step);
     test_step.dependOn(&run_demo_verb_1.step);
     test_step.dependOn(&run_demo_verb_2.step);
+    test_step.dependOn(&run_demo_verb_3.step);
+    test_step.dependOn(&run_demo_verb_4.step);
 }

--- a/demo_verb.zig
+++ b/demo_verb.zig
@@ -36,6 +36,8 @@ pub fn main() !u8 {
                     .f = "force",
                 };
             },
+            forward: void,
+            @"zero-sized": struct {},
         },
         argsAllocator,
         .print,
@@ -69,6 +71,8 @@ pub fn main() !u8 {
                 });
             }
         },
+        .forward => std.debug.print("\t`forward` verb with no options received\n", .{}),
+        .@"zero-sized" => std.debug.print("\t`zero-sized` verb received\n", .{}),
     }
 
     std.debug.print("parsed positionals:\n", .{});


### PR DESCRIPTION
This PR adds support for verbs with void/zero sized payload types.

Fixes #31 