### PR TITLE
fix panic in demo_verb

### DIFF
--- a/demo_verb.zig
+++ b/demo_verb.zig
@@ -54,25 +54,27 @@ pub fn main() !u8 {
         });
     }
     // verb options
-    switch (options.verb.?) {
-        .compact => |opts| {
-            inline for (std.meta.fields(@TypeOf(opts))) |fld| {
-                std.debug.print("\t{s} = {any}\n", .{
-                    fld.name,
-                    @field(opts, fld.name),
-                });
-            }
-        },
-        .reload => |opts| {
-            inline for (std.meta.fields(@TypeOf(opts))) |fld| {
-                std.debug.print("\t{s} = {any}\n", .{
-                    fld.name,
-                    @field(opts, fld.name),
-                });
-            }
-        },
-        .forward => std.debug.print("\t`forward` verb with no options received\n", .{}),
-        .@"zero-sized" => std.debug.print("\t`zero-sized` verb received\n", .{}),
+    if (options.verb) |verb| {
+        switch (verb) {
+            .compact => |opts| {
+                inline for (std.meta.fields(@TypeOf(opts))) |fld| {
+                    std.debug.print("\t{s} = {any}\n", .{
+                        fld.name,
+                        @field(opts, fld.name),
+                    });
+                }
+            },
+            .reload => |opts| {
+                inline for (std.meta.fields(@TypeOf(opts))) |fld| {
+                    std.debug.print("\t{s} = {any}\n", .{
+                        fld.name,
+                        @field(opts, fld.name),
+                    });
+                }
+            },
+            .forward => std.debug.print("\t`forward` verb with no options received\n", .{}),
+            .@"zero-sized" => std.debug.print("\t`zero-sized` verb received\n", .{}),
+        }
     }
 
     std.debug.print("parsed positionals:\n", .{});


### PR DESCRIPTION
Close #25 

demo_verb may panic when invoke without any verb,

Reproduce
- `zig run demo_verb.zig`
```
thread 22281042 panic: attempt to use null value
./demo_verb.zig:57:25: 0x100e5eb23 in main (demo_verb)
    switch (options.verb.?) {
```