### PR TITLE
make error kind enum public

### DIFF
--- a/args.zig
+++ b/args.zig
@@ -607,7 +607,7 @@ pub const Error = struct {
         }
     }
 
-    const Kind = union(enum) {
+    pub const Kind = union(enum) {
         /// When the argument itself is unknown
         unknown,
 


### PR DESCRIPTION
Related to issue #39 ... Can we make this error kind enum public? So that we can make better "custom" error messages.