### PR TITLE
Create build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = "zig-args",
+    .version = "0.0.0",
+    .minimum_zig_version = "0.12.0",
+
+    .paths = .{
+        "args.zig",
+        "demo.zig",
+        "demo_verb.zig",
+        "build.zig",
+    },
+}


### PR DESCRIPTION
This makes zig-args compatible with the built in zig package system.

What this means is that to add it to a project, now all you have to do is `zig fetch --save https://github.com/MasterQ32/zig-args/archive/<Version>.tar.gz`, and the only requirement to do this is zig itself