### PR TITLE
Optimize `parseBool`

### DIFF
--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: master
+          version: 0.12.0
 
       - name: Run the test suite
         run: |

--- a/args.zig
+++ b/args.zig
@@ -373,13 +373,18 @@ fn requiresArg(comptime T: type) bool {
 
 /// Parses a boolean option.
 fn parseBoolean(str: []const u8) !bool {
-    const map = std.ComptimeStringMap(bool, .{
-        .{ "yes", true },    .{ "y", true },
-        .{ "true", true },   .{ "t", true },
-        .{ "no", false },    .{ "n", false },
-        .{ "false", false }, .{ "f", false },
-    });
-    return map.get(str) orelse error.NotABooleanValue;
+    return switch (str.len) {
+        1 => switch (str[0]) {
+            'y', 'Y', 't', 'T' => true,
+            'n', 'N', 'f', 'F' => false,
+            else => error.NotABooleanValue,
+        },
+        2 => if (std.ascii.eqlIgnoreCase("no", str)) false else error.NotABooleanValue,
+        3 => if (std.ascii.eqlIgnoreCase("yes", str)) true else error.NotABooleanValue,
+        4 => if (std.ascii.eqlIgnoreCase("true", str)) true else error.NotABooleanValue,
+        5 => if (std.ascii.eqlIgnoreCase("false", str)) false else error.NotABooleanValue,
+        else => error.NotABooleanValue,
+    };
 }
 
 /// Parses an int option.

--- a/args.zig
+++ b/args.zig
@@ -373,20 +373,13 @@ fn requiresArg(comptime T: type) bool {
 
 /// Parses a boolean option.
 fn parseBoolean(str: []const u8) !bool {
-    return if (std.mem.eql(u8, str, "yes"))
-        true
-    else if (std.mem.eql(u8, str, "true"))
-        true
-    else if (std.mem.eql(u8, str, "y"))
-        true
-    else if (std.mem.eql(u8, str, "no"))
-        false
-    else if (std.mem.eql(u8, str, "false"))
-        false
-    else if (std.mem.eql(u8, str, "n"))
-        false
-    else
-        return error.NotABooleanValue;
+    const map = std.ComptimeStringMap(bool, .{
+        .{ "yes", true },    .{ "y", true },
+        .{ "true", true },   .{ "t", true },
+        .{ "no", false },    .{ "n", false },
+        .{ "false", false }, .{ "f", false },
+    });
+    return map.get(str) orelse error.NotABooleanValue;
 }
 
 /// Parses an int option.


### PR DESCRIPTION
Instead of repeatedly calling `std.mem.eql`, this would make a single call to `ComptimeStringMap.get`